### PR TITLE
Fix tf leak on marker(array) removal, SceneNode

### DIFF
--- a/src/markers/MarkerArrayClient.js
+++ b/src/markers/MarkerArrayClient.js
@@ -53,6 +53,7 @@ ROS3D.MarkerArrayClient = function(options) {
           updated = that.markers[message.ns + message.id].children[0].update(message);
           if(!updated) { // "REMOVE"
               that.rootObject.remove(that.markers[message.ns + message.id]);
+              that.markers[message.ns + message.id].removeTF();
           }
         }
         if(!updated) { // "ADD"
@@ -73,8 +74,11 @@ ROS3D.MarkerArrayClient = function(options) {
         console.warn('Received marker message with deprecated action identifier "1"');
       }
       else if(message.action === 2) { // "DELETE"
-        that.rootObject.remove(that.markers[message.ns + message.id]);
-        delete that.markers[message.ns + message.id];
+        if (message.ns + message.id in that.markers) {
+          that.rootObject.remove(that.markers[message.ns + message.id]);
+          that.markers[message.ns + message.id].removeTF();
+          delete that.markers[message.ns + message.id];
+        }
       }
       else if(message.action === 3) { // "DELETE ALL"
         for (var m in that.markers){

--- a/src/visualization/SceneNode.js
+++ b/src/visualization/SceneNode.js
@@ -17,8 +17,8 @@
 ROS3D.SceneNode = function(options) {
   options = options || {};
   var that = this;
-  var tfClient = options.tfClient || null;
-  var frameID = options.frameID;
+  this.tfClient = options.tfClient || null;
+  this.frameID = options.frameID;
   var object = options.object;
   this.pose = options.pose || new ROSLIB.Pose();
 
@@ -31,9 +31,11 @@ ROS3D.SceneNode = function(options) {
   // set the inital pose
   this.updatePose(this.pose);
 
+  this.tfCallback = function(tf) { that.transformPose(tf);};
+
   // listen for TF updates
-  if (tfClient) {
-      tfClient.subscribe(frameID, function(tf) { that.transformPose(tf);} );
+  if (this.tfClient) {
+      this.tfClient.subscribe(this.frameID, this.tfCallback );
   }
 
 };
@@ -72,9 +74,8 @@ ROS3D.SceneNode.prototype.transformPose = function(transform) {
  */
 ROS3D.SceneNode.prototype.removeTF = function() {
   if (this.tfClient) {
-    this.tfClient.unsubscribe(this.frameID, this.transformPose);
+    this.tfClient.unsubscribe(this.frameID, this.tfCallback);
   }
-  this.tfCallback = null;
 };
 
 /**


### PR DESCRIPTION
MarkerArray client was not calling the removeTF() cleanup func in the
other marker-removal actions/callbacks (besides DELETE ALL).

Further, the removeTF() SceneNode cleanup function was passing the
wrong func to tfClient's unsubscribe, because the subscribe callback
was created with an (unreferencable) anonymous func. Had to reintroduce
the this.tfCallback in order to be able to properly refer to the
callback AND scope the unsubscribe to the right 'this'.

---

It's possible these fixes should be applied elsewhere - I only focused on the MarkerArrayClient changes.
